### PR TITLE
send 404 instead of 200 for failed requests going to default backend

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,7 +29,7 @@ images = {
 @app.errorhandler(404)
 def page_not_found(e):
     # note that we set the 404 status explicitly
-    return render_template('hello.html', COLOR=color_codes[APP], IMAGE=images["404"])
+    return render_template('hello.html', COLOR=color_codes[APP], IMAGE=images["404"]), 404
 
 
 @app.route('/')


### PR DESCRIPTION
send 404 instead of the default 200 for the failed requests going to default backend - docs: https://flask.palletsprojects.com/en/2.0.x/quickstart/#redirects-and-errors